### PR TITLE
Update PushIOManagerPlugin.java for new override function in sdk 7.1.3

### DIFF
--- a/src/android/PushIOManagerPlugin.java
+++ b/src/android/PushIOManagerPlugin.java
@@ -155,6 +155,11 @@ public class PushIOManagerPlugin extends CordovaPlugin {
                 mDeepLinkUrl = deepLinkUrl;
                 mWebLinkUrl = webLinkUrl;
             }
+
+            @Override
+            public void onFailure(String error) {
+                Log.e("PushIO", "Failed to receive deep link: " + error);
+            }
         });
     }
 


### PR DESCRIPTION
# Description

Oracle CX Mobile SDK 7.1.3 introduces a new override which causing the cordova builds to fail. Have added the override lines to make the build to work

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Made this change and took a new successful build 

**Test Configuration**:
* Hardware: Macbook
* SDK: Oracle CX Mobile SDK - 7.1.3

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules